### PR TITLE
Rate limiting & retry behavior.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conductorone/baton-snipe-it
 go 1.21
 
 require (
-	github.com/conductorone/baton-sdk v0.1.31
+	github.com/conductorone/baton-sdk v0.1.33
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/spf13/cobra v1.8.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/conductorone/baton-sdk v0.1.31 h1:RhCUsXINoleCZ/FrMDXMP1RMhGN6zp+oOeZV6YEOdcI=
-github.com/conductorone/baton-sdk v0.1.31/go.mod h1:1VMycIep+HU8JXef2wenT3ECzx1w3Jr3KDQG+L6Mv30=
+github.com/conductorone/baton-sdk v0.1.33 h1:0kWu7yCEux+KgUOs1xoo0TFARwN8Tc9/KOP6c4HqdFs=
+github.com/conductorone/baton-sdk v0.1.33/go.mod h1:1VMycIep+HU8JXef2wenT3ECzx1w3Jr3KDQG+L6Mv30=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/snipe-it/client.go
+++ b/pkg/snipe-it/client.go
@@ -40,7 +40,7 @@ func (c *Client) Validate(ctx context.Context) error {
 		return err
 	}
 
-	req, err := c.NewRequest(ctx, http.MethodGet, u)
+	req, err := c.NewRequest(ctx, http.MethodGet, u, uhttp.WithAcceptJSONHeader())
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/wrapper.go
+++ b/vendor/github.com/conductorone/baton-sdk/pkg/uhttp/wrapper.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const ContentType = "Content-Type"
+
 type WrapperResponse struct {
 	Header     http.Header
 	Body       []byte
@@ -45,6 +47,9 @@ func NewBaseHttpClient(httpClient *http.Client) *BaseHttpClient {
 
 func WithJSONResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
+		if !helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
+			return fmt.Errorf("unexpected content type for json response: %s", resp.Header.Get(ContentType))
+		}
 		return json.Unmarshal(resp.Body, response)
 	}
 }
@@ -59,7 +64,7 @@ func WithErrorResponse(resource ErrorResponse) DoOption {
 			return nil
 		}
 
-		if !helpers.IsJSONContentType(resp.Header.Get("Content-Type")) {
+		if !helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
 			return fmt.Errorf("%v", string(resp.Body))
 		}
 
@@ -77,7 +82,7 @@ func WithErrorResponse(resource ErrorResponse) DoOption {
 
 func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 	return func(resp *WrapperResponse) error {
-		rl, err := helpers.ExtractRateLimitData(&resp.Header)
+		rl, err := helpers.ExtractRateLimitData(resp.StatusCode, &resp.Header)
 		if err != nil {
 			return err
 		}
@@ -85,6 +90,7 @@ func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 		resource.Limit = rl.Limit
 		resource.Remaining = rl.Remaining
 		resource.ResetAt = rl.ResetAt
+		resource.Status = rl.Status
 
 		return nil
 	}
@@ -92,7 +98,23 @@ func WithRatelimitData(resource *v2.RateLimitDescription) DoOption {
 
 func WithXMLResponse(response interface{}) DoOption {
 	return func(resp *WrapperResponse) error {
+		if !helpers.IsXMLContentType(resp.Header.Get(ContentType)) {
+			return fmt.Errorf("unexpected content type for xml response: %s", resp.Header.Get(ContentType))
+		}
 		return xml.Unmarshal(resp.Body, response)
+	}
+}
+
+func WithResponse(response interface{}) DoOption {
+	return func(resp *WrapperResponse) error {
+		if helpers.IsJSONContentType(resp.Header.Get(ContentType)) {
+			return WithJSONResponse(response)(resp)
+		}
+		if helpers.IsXMLContentType(resp.Header.Get(ContentType)) {
+			return WithXMLResponse(response)(resp)
+		}
+
+		return status.Error(codes.Unknown, "unsupported content type")
 	}
 }
 
@@ -127,11 +149,32 @@ func (c *BaseHttpClient) Do(req *http.Request, options ...DoOption) (*http.Respo
 		}
 	}
 
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return resp, status.Error(codes.Unavailable, resp.Status)
+	case http.StatusNotFound:
+		return resp, status.Error(codes.NotFound, resp.Status)
+	case http.StatusUnauthorized:
+		return resp, status.Error(codes.Unauthenticated, resp.Status)
+	case http.StatusForbidden:
+		return resp, status.Error(codes.PermissionDenied, resp.Status)
+	case http.StatusNotImplemented:
+		return resp, status.Error(codes.Unimplemented, resp.Status)
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return resp, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return resp, status.Error(codes.Unknown, fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
 	}
 
 	return resp, err
+}
+
+func WithHeader(key, value string) RequestOption {
+	return func() (io.ReadWriter, map[string]string, error) {
+		return nil, map[string]string{
+			key: value,
+		}, nil
+	}
 }
 
 func WithJSONBody(body interface{}) RequestOption {
@@ -152,27 +195,15 @@ func WithJSONBody(body interface{}) RequestOption {
 }
 
 func WithAcceptJSONHeader() RequestOption {
-	return func() (io.ReadWriter, map[string]string, error) {
-		return nil, map[string]string{
-			"Accept": "application/json",
-		}, nil
-	}
+	return WithHeader("Accept", "application/json")
 }
 
 func WithContentTypeJSONHeader() RequestOption {
-	return func() (io.ReadWriter, map[string]string, error) {
-		return nil, map[string]string{
-			"Content-Type": "application/json",
-		}, nil
-	}
+	return WithHeader("Content-Type", "application/json")
 }
 
 func WithAcceptXMLHeader() RequestOption {
-	return func() (io.ReadWriter, map[string]string, error) {
-		return nil, map[string]string{
-			"Accept": "application/xml",
-		}, nil
-	}
+	return WithHeader("Accept", "application/xml")
 }
 
 func (c *BaseHttpClient) NewRequest(ctx context.Context, method string, url *url.URL, options ...RequestOption) (*http.Request, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/aws/smithy-go/waiter
 # github.com/benbjohnson/clock v1.3.5
 ## explicit; go 1.15
 github.com/benbjohnson/clock
-# github.com/conductorone/baton-sdk v0.1.31
+# github.com/conductorone/baton-sdk v0.1.33
 ## explicit; go 1.20
 github.com/conductorone/baton-sdk/internal/connector
 github.com/conductorone/baton-sdk/pb/c1/c1z/v1


### PR DESCRIPTION
This upgrades baton-sdk to v0.1.33, which has retry behavior if an error returns GRPC status Unavailable. Also it sets the accept header to application/json, so that Snipe-IT's API error messages are JSON instead of HTML. Finally it tries to parse rate limit headers, though Snipe-IT doesn't seem to return rate limit info in many cases.