### PR TITLE
Actually return role grants

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -273,7 +273,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pa
 		return nil, "", annos, err
 	}
 
-	return nil, nextPage, annos, nil
+	return rv, nextPage, annos, nil
 }
 
 func (r *roleResourceType) getGrantsFromPermissions(permissions snipeit.Permissions, roleResource *v2.Resource, resource *v2.Resource) ([]*v2.Grant, error) {


### PR DESCRIPTION
We're returning nil instead of the collected grants when listing grants for roles. This returns them.