### PR TITLE
Add expansion for groups on role grants

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -237,7 +237,17 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pa
 				return nil, "", annos, wrapError(err, "Failed to get group grants")
 			}
 
-			rv = append(rv, grants...)
+			for _, g := range grants {
+				annos := annotations.Annotations(g.Annotations)
+				annos.Update(&v2.GrantExpandable{
+					EntitlementIds: []string{
+						ent.NewEntitlementID(groupResource, "member"),
+					},
+					Shallow:         true,
+					ResourceTypeIds: []string{resourceTypeUser.Id},
+				})
+				rv = append(rv, g)
+			}
 		}
 	}
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -246,6 +246,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pa
 					Shallow:         true,
 					ResourceTypeIds: []string{resourceTypeUser.Id},
 				})
+				g.Annotations = annos
 				rv = append(rv, g)
 			}
 		}


### PR DESCRIPTION
If a group is granted a role, we want to expand the grant to the group's members.

Note: this still requires some testing, but I don't have a functioning environment to test with yet.