### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -39,10 +39,9 @@ func groupResource(ctx context.Context, group *snipeit.Group) (*v2.Resource, err
 		"group_id": group.ID,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
-	resource, err := rs.NewGroupResource(group.Name, resourceTypeGroup, group.ID, groupTraitOptions)
+	groupTraitOptions := []rs.GroupTraitOption{}
+	resource, err := rs.NewGroupResource(group.Name, resourceTypeGroup, group.ID, groupTraitOptions,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -44,11 +44,10 @@ func roleResource(ctx context.Context, role string) (*v2.Resource, error) {
 		"name": role,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []rs.RoleTraitOption{}
 
-	resource, err := rs.NewRoleResource(role, resourceTypeRole, role, roleTraitOptions)
+	resource, err := rs.NewRoleResource(role, resourceTypeRole, role, roleTraitOptions,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -50,14 +50,14 @@ func userResource(ctx context.Context, user *snipeit.User) (*v2.Resource, error)
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(user.Email, true),
 		rs.WithUserLogin(user.Username),
-		rs.WithStatus(getUserStatus(user)),
 	}
 
 	fullName := fmt.Sprintf("%s %s", user.FirstName, user.LastName)
-	resource, err := rs.NewUserResource(fullName, resourceTypeUser, user.ID, userTraitOptions)
+	resource, err := rs.NewUserResource(fullName, resourceTypeUser, user.ID, userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(getUserStatus(user)), ""))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
